### PR TITLE
Gate Keeper Changes

### DIFF
--- a/gate-keeper/packages/contracts/src/systems/gate_keeper/GateKeeper.sol
+++ b/gate-keeper/packages/contracts/src/systems/gate_keeper/GateKeeper.sol
@@ -98,7 +98,7 @@ contract GateKeeper is System {
     );
 
     if (quantityInInventory + quantity > gatekeeperConfig.targetItemQuantity) {
-      quantity = quantity - ((quantityInInventory + quantity) - gatekeeperConfig.targetItemQuantity);
+      quantity = gatekeeperConfig.targetItemQuantity - quantityInInventory ;
     }
 
     if (quantityInInventory + quantity == gatekeeperConfig.targetItemQuantity) {


### PR DESCRIPTION
Made the gatekeeper only accept as much as it can until the goal instead of reverting. 

I did this for useability for players to ensure if players want to either donate a large amount, the goal is small or the goal is close to being completed it can still be donated to.