### PR TITLE
fix: issue with garnet missing from supported chains

### DIFF
--- a/item-seller/packages/client/src/mud/supportedChains.ts
+++ b/item-seller/packages/client/src/mud/supportedChains.ts
@@ -11,10 +11,10 @@
 
  */
 
-import { MUDChain, latticeTestnet, mudFoundry } from "@latticexyz/common/chains";
+import { MUDChain, garnet, latticeTestnet, mudFoundry } from "@latticexyz/common/chains";
 
 /*
  * See https://mud.dev/tutorials/minimal/deploy#run-the-user-interface
  * for instructions on how to add networks.
  */
-export const supportedChains: MUDChain[] = [mudFoundry, latticeTestnet];
+export const supportedChains: MUDChain[] = [mudFoundry, latticeTestnet, garnet];


### PR DESCRIPTION
### Description
Fixes an issue with garnet network missing from item-seller client ui supported chains list.