### PR TITLE
remove store-indexer dependency

### DIFF
--- a/item-trade/mprocs.yaml
+++ b/item-trade/mprocs.yaml
@@ -8,14 +8,6 @@ procs:
   anvil:
     cwd: packages/contracts
     shell: anvil --base-fee 0 --block-time 2
-  indexer:
-    cwd: packages/contracts
-    shell: shx rm -rf $SQLITE_FILENAME && pnpm sqlite-indexer
-    env:
-      DEBUG: mud:*
-      RPC_HTTP_URL: "http://127.0.0.1:8545"
-      FOLLOW_BLOCK_TAG: "latest"
-      SQLITE_FILENAME: "indexer.db"
   explorer:
     cwd: packages/contracts
     shell: pnpm explorer

--- a/item-trade/package.json
+++ b/item-trade/package.json
@@ -15,7 +15,6 @@
     "@latticexyz/cli": "2.2.9",
     "@latticexyz/common": "2.2.9",
     "@latticexyz/explorer": "2.2.9",
-    "@latticexyz/store-indexer": "2.2.9",
     "@types/debug": "4.1.7",
     "@typescript-eslint/eslint-plugin": "7.1.1",
     "@typescript-eslint/parser": "7.1.1",

--- a/item-trade/pnpm-lock.yaml
+++ b/item-trade/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@latticexyz/explorer':
         specifier: 2.2.9
         version: 2.2.9(@babel/core@7.25.2)(react-native@0.75.3)(typescript@5.4.2)
-      '@latticexyz/store-indexer':
-        specifier: 2.2.9
-        version: 2.2.9(react@18.3.1)(typescript@5.4.2)
       '@types/debug':
         specifier: 4.1.7
         version: 4.1.7

--- a/smart-gate/mprocs.yaml
+++ b/smart-gate/mprocs.yaml
@@ -8,14 +8,6 @@ procs:
   anvil:
     cwd: packages/contracts
     shell: anvil --base-fee 0 --block-time 2
-  indexer:
-    cwd: packages/contracts
-    shell: shx rm -rf $SQLITE_FILENAME && pnpm sqlite-indexer
-    env:
-      DEBUG: mud:*
-      RPC_HTTP_URL: "http://127.0.0.1:8545"
-      FOLLOW_BLOCK_TAG: "latest"
-      SQLITE_FILENAME: "indexer.db"
   explorer:
     cwd: packages/contracts
     shell: pnpm explorer

--- a/smart-gate/package.json
+++ b/smart-gate/package.json
@@ -15,7 +15,6 @@
     "@latticexyz/cli": "2.2.9",
     "@latticexyz/common": "2.2.9",
     "@latticexyz/explorer": "2.2.9",
-    "@latticexyz/store-indexer": "2.2.9",
     "@types/debug": "4.1.7",
     "@typescript-eslint/eslint-plugin": "7.1.1",
     "@typescript-eslint/parser": "7.1.1",

--- a/smart-gate/pnpm-lock.yaml
+++ b/smart-gate/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@latticexyz/explorer':
         specifier: 2.2.9
         version: 2.2.9(@babel/core@7.25.2)(react-native@0.75.3)(typescript@5.4.2)
-      '@latticexyz/store-indexer':
-        specifier: 2.2.9
-        version: 2.2.9(react@18.3.1)(typescript@5.4.2)
       '@types/debug':
         specifier: 4.1.7
         version: 4.1.7

--- a/smart-turret/mprocs.yaml
+++ b/smart-turret/mprocs.yaml
@@ -8,14 +8,6 @@ procs:
   anvil:
     cwd: packages/contracts
     shell: anvil --base-fee 0 --block-time 2
-  indexer:
-    cwd: packages/contracts
-    shell: shx rm -rf $SQLITE_FILENAME && pnpm sqlite-indexer
-    env:
-      DEBUG: mud:*
-      RPC_HTTP_URL: "http://127.0.0.1:8545"
-      FOLLOW_BLOCK_TAG: "latest"
-      SQLITE_FILENAME: "indexer.db"
   explorer:
     cwd: packages/contracts
     shell: pnpm explorer

--- a/smart-turret/package.json
+++ b/smart-turret/package.json
@@ -15,7 +15,6 @@
     "@latticexyz/cli": "2.2.9",
     "@latticexyz/common": "2.2.9",
     "@latticexyz/explorer": "2.2.9",
-    "@latticexyz/store-indexer": "2.2.9",
     "@types/debug": "4.1.7",
     "@typescript-eslint/eslint-plugin": "7.1.1",
     "@typescript-eslint/parser": "7.1.1",

--- a/smart-turret/pnpm-lock.yaml
+++ b/smart-turret/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@latticexyz/explorer':
         specifier: 2.2.9
         version: 2.2.9(@babel/core@7.25.2)(react-native@0.75.3)(typescript@5.4.2)
-      '@latticexyz/store-indexer':
-        specifier: 2.2.9
-        version: 2.2.9(react@18.3.1)(typescript@5.4.2)
       '@types/debug':
         specifier: 4.1.7
         version: 4.1.7


### PR DESCRIPTION
`@latticexyz/store-indexer` is already included in the `@latticexyz/explorer`, and thus is not required to be run separately.