### PR TITLE
upgrade mprocs

### DIFF
--- a/gate-keeper/package.json
+++ b/gate-keeper/package.json
@@ -12,13 +12,13 @@
   },
   "devDependencies": {
     "@latticexyz/cli": "2.2.9",
+    "@latticexyz/explorer": "2.2.9",
     "@types/debug": "4.1.7",
     "@types/prettier": "2.7.2",
     "@typescript-eslint/eslint-plugin": "5.46.1",
     "@typescript-eslint/parser": "5.46.1",
-    "@latticexyz/explorer": "2.2.9",
     "eslint": "8.29.0",
-    "mprocs": "^0.6.4",
+    "mprocs": "^0.7.1",
     "rimraf": "^3.0.2",
     "typescript": "5.1.6"
   },

--- a/gate-keeper/pnpm-lock.yaml
+++ b/gate-keeper/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: 8.29.0
         version: 8.29.0
       mprocs:
-        specifier: ^0.6.4
-        version: 0.6.4
+        specifier: ^0.7.1
+        version: 0.7.1
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -11334,8 +11334,8 @@ packages:
       '@motionone/vue': 10.16.4
     dev: true
 
-  /mprocs@0.6.4:
-    resolution: {integrity: sha512-Y4eqnAjp3mjy0eT+zPoMQ+P/ISOzjgRG/4kh4I5cRA4Tv0rPxTCBRadn3+j+boMF5id7IoLhrVq9NFWFPuzD9A==}
+  /mprocs@0.7.1:
+    resolution: {integrity: sha512-v22SIwcOphZm6XLdNfeHf4ZDYHqV1hghyfqNLwmZ604lEXlEkiuazYBWUz3xEB2GdABEAKfCZ8qiOVIoREM6CQ==}
     engines: {node: '>=0.10.0'}
     hasBin: true
     dev: true

--- a/item-seller/package.json
+++ b/item-seller/package.json
@@ -11,13 +11,13 @@
   },
   "devDependencies": {
     "@latticexyz/cli": "2.2.9",
+    "@latticexyz/explorer": "2.2.9",
     "@types/debug": "4.1.7",
     "@types/prettier": "2.7.2",
     "@typescript-eslint/eslint-plugin": "5.46.1",
     "@typescript-eslint/parser": "5.46.1",
-    "@latticexyz/explorer": "2.2.9",
     "eslint": "8.29.0",
-    "mprocs": "^0.6.4",
+    "mprocs": "^0.7.1",
     "rimraf": "^3.0.2",
     "typescript": "5.1.6"
   },

--- a/item-seller/pnpm-lock.yaml
+++ b/item-seller/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: 8.29.0
         version: 8.29.0
       mprocs:
-        specifier: ^0.6.4
-        version: 0.6.4
+        specifier: ^0.7.1
+        version: 0.7.1
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -12157,8 +12157,8 @@ packages:
       '@motionone/vue': 10.16.4
     dev: true
 
-  /mprocs@0.6.4:
-    resolution: {integrity: sha512-Y4eqnAjp3mjy0eT+zPoMQ+P/ISOzjgRG/4kh4I5cRA4Tv0rPxTCBRadn3+j+boMF5id7IoLhrVq9NFWFPuzD9A==}
+  /mprocs@0.7.1:
+    resolution: {integrity: sha512-v22SIwcOphZm6XLdNfeHf4ZDYHqV1hghyfqNLwmZ604lEXlEkiuazYBWUz3xEB2GdABEAKfCZ8qiOVIoREM6CQ==}
     engines: {node: '>=0.10.0'}
     hasBin: true
     dev: true

--- a/item-trade/package.json
+++ b/item-trade/package.json
@@ -19,7 +19,7 @@
     "@typescript-eslint/eslint-plugin": "7.1.1",
     "@typescript-eslint/parser": "7.1.1",
     "eslint": "8.57.0",
-    "mprocs": "^0.6.4",
+    "mprocs": "^0.7.1",
     "shx": "^0.3.4",
     "typescript": "5.4.2"
   },

--- a/item-trade/pnpm-lock.yaml
+++ b/item-trade/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: 8.57.0
         version: 8.57.0
       mprocs:
-        specifier: ^0.6.4
-        version: 0.6.4
+        specifier: ^0.7.1
+        version: 0.7.1
       shx:
         specifier: ^0.3.4
         version: 0.3.4
@@ -11879,8 +11879,8 @@ packages:
       '@motionone/vue': 10.16.4
     dev: true
 
-  /mprocs@0.6.4:
-    resolution: {integrity: sha512-Y4eqnAjp3mjy0eT+zPoMQ+P/ISOzjgRG/4kh4I5cRA4Tv0rPxTCBRadn3+j+boMF5id7IoLhrVq9NFWFPuzD9A==}
+  /mprocs@0.7.1:
+    resolution: {integrity: sha512-v22SIwcOphZm6XLdNfeHf4ZDYHqV1hghyfqNLwmZ604lEXlEkiuazYBWUz3xEB2GdABEAKfCZ8qiOVIoREM6CQ==}
     engines: {node: '>=0.10.0'}
     hasBin: true
     dev: true

--- a/smart-gate/package.json
+++ b/smart-gate/package.json
@@ -19,7 +19,7 @@
     "@typescript-eslint/eslint-plugin": "7.1.1",
     "@typescript-eslint/parser": "7.1.1",
     "eslint": "8.57.0",
-    "mprocs": "^0.6.4",
+    "mprocs": "^0.7.1",
     "shx": "^0.3.4",
     "typescript": "5.4.2"
   },

--- a/smart-gate/pnpm-lock.yaml
+++ b/smart-gate/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: 8.57.0
         version: 8.57.0
       mprocs:
-        specifier: ^0.6.4
-        version: 0.6.4
+        specifier: ^0.7.1
+        version: 0.7.1
       shx:
         specifier: ^0.3.4
         version: 0.3.4
@@ -11036,8 +11036,8 @@ packages:
       '@motionone/vue': 10.16.4
     dev: true
 
-  /mprocs@0.6.4:
-    resolution: {integrity: sha512-Y4eqnAjp3mjy0eT+zPoMQ+P/ISOzjgRG/4kh4I5cRA4Tv0rPxTCBRadn3+j+boMF5id7IoLhrVq9NFWFPuzD9A==}
+  /mprocs@0.7.1:
+    resolution: {integrity: sha512-v22SIwcOphZm6XLdNfeHf4ZDYHqV1hghyfqNLwmZ604lEXlEkiuazYBWUz3xEB2GdABEAKfCZ8qiOVIoREM6CQ==}
     engines: {node: '>=0.10.0'}
     hasBin: true
     dev: true

--- a/smart-turret/package.json
+++ b/smart-turret/package.json
@@ -19,7 +19,7 @@
     "@typescript-eslint/eslint-plugin": "7.1.1",
     "@typescript-eslint/parser": "7.1.1",
     "eslint": "8.57.0",
-    "mprocs": "^0.6.4",
+    "mprocs": "^0.7.1",
     "shx": "^0.3.4",
     "typescript": "5.4.2"
   },

--- a/smart-turret/pnpm-lock.yaml
+++ b/smart-turret/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: 8.57.0
         version: 8.57.0
       mprocs:
-        specifier: ^0.6.4
-        version: 0.6.4
+        specifier: ^0.7.1
+        version: 0.7.1
       shx:
         specifier: ^0.3.4
         version: 0.3.4
@@ -11036,8 +11036,8 @@ packages:
       '@motionone/vue': 10.16.4
     dev: true
 
-  /mprocs@0.6.4:
-    resolution: {integrity: sha512-Y4eqnAjp3mjy0eT+zPoMQ+P/ISOzjgRG/4kh4I5cRA4Tv0rPxTCBRadn3+j+boMF5id7IoLhrVq9NFWFPuzD9A==}
+  /mprocs@0.7.1:
+    resolution: {integrity: sha512-v22SIwcOphZm6XLdNfeHf4ZDYHqV1hghyfqNLwmZ604lEXlEkiuazYBWUz3xEB2GdABEAKfCZ8qiOVIoREM6CQ==}
     engines: {node: '>=0.10.0'}
     hasBin: true
     dev: true

--- a/vending-machine/package.json
+++ b/vending-machine/package.json
@@ -12,13 +12,13 @@
   },
   "devDependencies": {
     "@latticexyz/cli": "2.2.9",
+    "@latticexyz/explorer": "2.2.9",
     "@types/debug": "4.1.7",
     "@types/prettier": "2.7.2",
     "@typescript-eslint/eslint-plugin": "5.46.1",
     "@typescript-eslint/parser": "5.46.1",
-    "@latticexyz/explorer": "2.2.9",
     "eslint": "8.29.0",
-    "mprocs": "^0.6.4",
+    "mprocs": "^0.7.1",
     "rimraf": "^3.0.2",
     "typescript": "5.1.6"
   },

--- a/vending-machine/pnpm-lock.yaml
+++ b/vending-machine/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: 8.29.0
         version: 8.29.0
       mprocs:
-        specifier: ^0.6.4
-        version: 0.6.4
+        specifier: ^0.7.1
+        version: 0.7.1
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -11337,8 +11337,8 @@ packages:
       '@motionone/vue': 10.16.4
     dev: true
 
-  /mprocs@0.6.4:
-    resolution: {integrity: sha512-Y4eqnAjp3mjy0eT+zPoMQ+P/ISOzjgRG/4kh4I5cRA4Tv0rPxTCBRadn3+j+boMF5id7IoLhrVq9NFWFPuzD9A==}
+  /mprocs@0.7.1:
+    resolution: {integrity: sha512-v22SIwcOphZm6XLdNfeHf4ZDYHqV1hghyfqNLwmZ604lEXlEkiuazYBWUz3xEB2GdABEAKfCZ8qiOVIoREM6CQ==}
     engines: {node: '>=0.10.0'}
     hasBin: true
     dev: true


### PR DESCRIPTION
Noticed that processes can fail silently on mprocs v6. Upgraded to the latest version which is more stable.