### PR TITLE
Add 'view' Keyword to Functions

### DIFF
--- a/smart-turret/packages/contracts/src/systems/SmartTurretSystem.sol
+++ b/smart-turret/packages/contracts/src/systems/SmartTurretSystem.sol
@@ -43,7 +43,7 @@ contract SmartTurretSystem is System {
     TargetPriority[] memory priorityQueue,
     Turret memory turret,
     SmartTurretTarget memory turretTarget
-  ) public returns (TargetPriority[] memory updatedPriorityQueue) {
+  ) public view returns (TargetPriority[] memory updatedPriorityQueue) {
     //TODO: Implement the logic
     
     if(true){
@@ -67,7 +67,7 @@ contract SmartTurretSystem is System {
     Turret memory turret,
     SmartTurretTarget memory aggressor,
     SmartTurretTarget memory victim
-  ) public returns (TargetPriority[] memory updatedPriorityQueue) {
+  ) public view returns (TargetPriority[] memory updatedPriorityQueue) {
     //TODO: Implement the logic
     
     return priorityQueue;


### PR DESCRIPTION
I might be overstepping a bit here, but it leaves builders a little confused since there seems to be a duality here.  Even though these functions are supposedly invoked with eth_call() by the World contract (effectively making them read-only), any builder will assume that these functions (upon being read for the first time) will follow default behavior and invoke transactions.  Would it be better for clarity to have the 'view' keyword specified?

Again, I may not be privy to design decisions, and I could be completely wrong.  Thanks for taking any requests into consideration!