### PR TITLE
PNPM Version updates for security vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ nvm install 18
 #### Installing PNPM
 Install PNPM version 8, which is used as a more efficient version of NPM with:
 ```bash
-npm install -g pnpm@latest-8
+npm install -g pnpm
 ```
 
 ### Step 0.1: Installing Foundry + Forge

--- a/smart-assembly-scaffold/package.json
+++ b/smart-assembly-scaffold/package.json
@@ -50,7 +50,7 @@
   },
   "engines": {
     "node": "^18",
-    "pnpm": "^8 || ^9"
+    "pnpm": ">=9.15.0"
   },
   "//pnpm": {
     "overrides": {

--- a/smart-gate/package.json
+++ b/smart-gate/package.json
@@ -26,7 +26,7 @@
   },
   "engines": {
     "node": "^18",
-    "pnpm": "^8 || ^9"
+    "pnpm": ">=9.15.0"
   },
   "packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c"
 }

--- a/smart-storage-unit/package.json
+++ b/smart-storage-unit/package.json
@@ -24,7 +24,7 @@
   },
   "engines": {
     "node": "18.x",
-    "pnpm": "^8 || ^9"
+    "pnpm": ">=9.15.0"
   },
   "packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c"
 }

--- a/smart-turret/package.json
+++ b/smart-turret/package.json
@@ -25,7 +25,7 @@
   },
   "engines": {
     "node": "^18",
-    "pnpm": "^8 || ^9"
+    "pnpm": ">=9.15.0"
   },
   "packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c"
 }


### PR DESCRIPTION
Updated the required pnpm version to be 9.15.0 or higher as there is a security vulnerability for versions lower than 9.15 which you can see here: https://github.com/advisories/GHSA-vm32-9rqf-rh3r 

Will also be updating the documentation website once this PR is accepted with the new version.