### PR TITLE
Fix for the Foundry Image not being able to be pulled

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@
 services:
   foundry:
     container_name: foundry
-    image: ghcr.io/foundry-rs/foundry:nightly-d14c09f15a9849fe177d097451919810e5877617
+    image: ghcr.io/foundry-rs/foundry:stable
     platform: linux/amd64 # Specify the platform
     entrypoint: anvil --block-time 1 --block-base-fee-per-gas 0 --gas-limit 3000000000 --hardfork cancun --host 0.0.0.0 --port 8546
     ports:


### PR DESCRIPTION
It seems like the nightly that was referenced potentially isn't hosted anymore. I've moved it over to stable so that the issue doesn't happen again and to fix it. 