### PR TITLE
Remove shell script references

### DIFF
--- a/smart-storage-unit/package.json
+++ b/smart-storage-unit/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "pnpm recursive run build",
-    "dev": "bash ./shell-scripts/CheckEnv.sh && . ./packages/contracts/.env && mprocs",
+    "dev": ". ./packages/contracts/.env && mprocs",
     "dev:client": "pnpm --filter 'client' run dev",
     "dev:contracts": "pnpm --filter 'contracts' dev",
     "foundry:up": "curl -L https://foundry.paradigm.xyz | bash && bash $HOME/.foundry/bin/foundryup",

--- a/smart-turret/package.json
+++ b/smart-turret/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "pnpm recursive run build",
-    "dev": "bash ./shell-scripts/CheckEnv.sh && . ./packages/contracts/.env && mprocs",
+    "dev": ". ./packages/contracts/.env && mprocs",
     "dev:client": "pnpm --filter 'client' run dev",
     "dev:contracts": "pnpm --filter 'contracts' dev",
     "foundry:up": "curl -L https://foundry.paradigm.xyz | bash && bash $HOME/.foundry/bin/foundryup",


### PR DESCRIPTION
It still had two shell script references in the package files left over from the migration to the new CLI tool.