### PR TITLE
Automatic Unit Testing in pnpm dev

### DIFF
--- a/smart-gate/mprocs.yaml
+++ b/smart-gate/mprocs.yaml
@@ -8,6 +8,9 @@ procs:
   anvil:
     cwd: packages/contracts
     shell: anvil --base-fee 0 --block-time 2 --fork-url http://127.0.0.1:8546
+  tests:
+    cwd: packages/contracts
+    shell: pnpm test-watch
   explorer:
     cwd: packages/contracts
     shell: pnpm explorer

--- a/smart-gate/packages/contracts/package.json
+++ b/smart-gate/packages/contracts/package.json
@@ -16,7 +16,7 @@
     "solhint": "solhint --config ./.solhint.json 'src/**/*.sol' --fix",
     "test:deploy": "mud test",
     "test": ". ./.env && forge test --fork-url $RPC_URL",
-    "test:watch": ". ./.env && forge test --fork-url $RPC_URL --watch",
+    "test-watch": ". ./.env && forge test --fork-url $RPC_URL --watch ./deploys ./script ./test --run-all",
     "mock-data": ". ./.env && pnpm forge script ./script/MockData.s.sol:MockData --broadcast --rpc-url $RPC_URL --chain-id $CHAIN_ID --sig \"run(address)\" $WORLD_ADDRESS -vvv",
     "configure": ". ./.env && pnpm forge script ./script/ConfigureSmartGate.s.sol:ConfigureSmartGate --broadcast --rpc-url $RPC_URL --chain-id $CHAIN_ID --sig \"run(address)\" $WORLD_ADDRESS -vvv",
     "link-gates": ". ./.env && pnpm forge script ./script/LinkGates.s.sol:LinkGates --broadcast --rpc-url $RPC_URL --chain-id $CHAIN_ID --sig \"run(address)\" $WORLD_ADDRESS -vvv",

--- a/smart-turret/packages/contracts/package.json
+++ b/smart-turret/packages/contracts/package.json
@@ -16,7 +16,7 @@
     "solhint": "solhint --config ./.solhint.json 'src/**/*.sol' --fix",
     "test:deploy": "mud test",
     "test": ". ./.env && forge test --fork-url $RPC_URL",
-    "test-watch": ". ./.env && forge test --fork-url $RPC_URL --watch",
+    "test-watch": ". ./.env && forge test --fork-url $RPC_URL --watch ./deploys ./script ./test --run-all",
     "mock-data": ". ./.env && pnpm forge script ./script/MockData.s.sol:MockData --broadcast --rpc-url $RPC_URL --chain-id $CHAIN_ID --sig \"run(address)\" $WORLD_ADDRESS -vvv > output.log 2>&1",
     "configure": ". ./.env && pnpm forge script ./script/ConfigureSmartTurret.s.sol:ConfigureSmartTurret --broadcast --rpc-url $RPC_URL --chain-id $CHAIN_ID --sig \"run(address)\" $WORLD_ADDRESS -vvv",
     "execute": ". ./.env && pnpm forge script ./script/ExecuteInProximity.s.sol:ExecuteInProximity --broadcast --rpc-url $RPC_URL --chain-id $CHAIN_ID --sig \"run(address)\" $WORLD_ADDRESS -vv",

--- a/smart-turret/pnpm-lock.yaml
+++ b/smart-turret/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   better-sqlite3: ^9.4.3
-  '@eveworld/smart-object-framework-v2': 0.1.1
+  '@eveworld/smart-object-framework-v2': 0.1.2
 
 importers:
 
@@ -43,8 +43,8 @@ importers:
         specifier: 0.0.13
         version: 0.0.13(@aws-sdk/client-kms@3.812.0)(asn1.js@5.4.1)(bufferutil@4.0.9)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8)
       '@eveworld/smart-object-framework-v2':
-        specifier: 0.1.1
-        version: 0.1.1(@aws-sdk/client-kms@3.812.0)(@opentelemetry/api@1.9.0)(asn1.js@5.4.1)(better-sqlite3@9.6.0)(bufferutil@4.0.9)(pg@8.16.1)(react@18.3.1)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8)
+        specifier: 0.1.2
+        version: 0.1.2(@aws-sdk/client-kms@3.812.0)(@opentelemetry/api@1.9.0)(asn1.js@5.4.1)(better-sqlite3@9.6.0)(bufferutil@4.0.9)(pg@8.16.1)(react@18.3.1)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8)
       '@eveworld/world-v2':
         specifier: 0.1.2
         version: 0.1.2(@aws-sdk/client-kms@3.812.0)(@opentelemetry/api@1.9.0)(asn1.js@5.4.1)(better-sqlite3@9.6.0)(bufferutil@4.0.9)(pg@8.16.1)(react@18.3.1)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8)
@@ -587,8 +587,8 @@ packages:
   '@eveworld/common-constants@0.0.13':
     resolution: {integrity: sha512-SI3RZhejBq7hNyLst32OCuhmpyKwrWg98EVnAQm8q/9yiLRSWIMe9xS3fflcfKrm+C7yE1lpESNgxI0gOi09ww==}
 
-  '@eveworld/smart-object-framework-v2@0.1.1':
-    resolution: {integrity: sha512-MMMQlhIC/MW3xrwuLDuZffBJsHnBiNbwpXJoDCVgiw3bdhjAmCS+rFYscFvvL3UMe4rINYq7IGjTt8+f2OqBfg==}
+  '@eveworld/smart-object-framework-v2@0.1.2':
+    resolution: {integrity: sha512-V5IDK+Upg4P5EWXefgOfMcACu3vcVhckorvmT8iU111/7E2aC2Eo40kGe63biHB25pnH146qyQQyfa8WX6PHNQ==}
 
   '@eveworld/world-v2@0.1.2':
     resolution: {integrity: sha512-UVfz1UdjhWSVmjrwK9UJbnnrfWuHYUgEAsORAK8+1b1I/wGA4+06023MQXZXkC8fywcS6RweIkRYTz4g/140Kg==}
@@ -5931,7 +5931,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@eveworld/smart-object-framework-v2@0.1.1(@aws-sdk/client-kms@3.812.0)(@opentelemetry/api@1.9.0)(asn1.js@5.4.1)(better-sqlite3@9.6.0)(bufferutil@4.0.9)(pg@8.16.1)(react@18.3.1)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8)':
+  '@eveworld/smart-object-framework-v2@0.1.2(@aws-sdk/client-kms@3.812.0)(@opentelemetry/api@1.9.0)(asn1.js@5.4.1)(better-sqlite3@9.6.0)(bufferutil@4.0.9)(pg@8.16.1)(react@18.3.1)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8)':
     dependencies:
       '@latticexyz/cli': 2.2.15-main-ba5191c3d6f74b3c4982afd465cf449d23d70bb7(@opentelemetry/api@1.9.0)(better-sqlite3@9.6.0)(bufferutil@4.0.9)(pg@8.16.1)(react@18.3.1)(utf-8-validate@5.0.10)
       '@latticexyz/schema-type': 2.2.15-main-ba5191c3d6f74b3c4982afd465cf449d23d70bb7(bufferutil@4.0.9)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8)
@@ -5969,7 +5969,7 @@ snapshots:
 
   '@eveworld/world-v2@0.1.2(@aws-sdk/client-kms@3.812.0)(@opentelemetry/api@1.9.0)(asn1.js@5.4.1)(better-sqlite3@9.6.0)(bufferutil@4.0.9)(pg@8.16.1)(react@18.3.1)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8)':
     dependencies:
-      '@eveworld/smart-object-framework-v2': 0.1.1(@aws-sdk/client-kms@3.812.0)(@opentelemetry/api@1.9.0)(asn1.js@5.4.1)(better-sqlite3@9.6.0)(bufferutil@4.0.9)(pg@8.16.1)(react@18.3.1)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8)
+      '@eveworld/smart-object-framework-v2': 0.1.2(@aws-sdk/client-kms@3.812.0)(@opentelemetry/api@1.9.0)(asn1.js@5.4.1)(better-sqlite3@9.6.0)(bufferutil@4.0.9)(pg@8.16.1)(react@18.3.1)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8)
       '@latticexyz/cli': 2.2.15-main-ba5191c3d6f74b3c4982afd465cf449d23d70bb7(@opentelemetry/api@1.9.0)(better-sqlite3@9.6.0)(bufferutil@4.0.9)(pg@8.16.1)(react@18.3.1)(utf-8-validate@5.0.10)
       '@latticexyz/gas-report': 2.2.15-main-ba5191c3d6f74b3c4982afd465cf449d23d70bb7
       '@latticexyz/schema-type': 2.2.15-main-ba5191c3d6f74b3c4982afd465cf449d23d70bb7(bufferutil@4.0.9)(typescript@5.4.2)(utf-8-validate@5.0.10)(zod@3.23.8)


### PR DESCRIPTION
Only a small change, but for the examples that have unit tests have made it automatically detect deploys + changes to run the tests so it's easier to monitor. This also means that you don't have to restart the mproc process after it's deployed. 