### PR TITLE
`sanitizeEnv.sh` update

### DIFF
--- a/sanitizeEnv.sh
+++ b/sanitizeEnv.sh
@@ -23,7 +23,7 @@ function sanitize() {
     sed "$@" "s/^CHAIN_ID=.*/CHAIN_ID=$CHAIN_ID #Local Chain ID/" "$FILE_NAME"
     sed "$@" "s|^RPC_URL=.*|RPC_URL=$RPC_URL #Forked Anvil Forked Anvil Local RPC Url|" "$FILE_NAME"
 
-    printf "\n${GREEN}[SANITIZED]${RESET} file ${YELLOW}${FILE_NAME}${RESET}\n\n"
+    printf "\n%b[SANITIZED]%b file %b%s%b\n\n" "${GREEN}" "${RESET}" "${YELLOW}" "${FILE_NAME}" "${RESET}"
 }
 
 sanitize "smart-gate/packages/contracts/.env"

--- a/sanitizeEnv.sh
+++ b/sanitizeEnv.sh
@@ -12,10 +12,16 @@ RESET="\033[0m"
 
 function sanitize() {
     FILE_NAME=$1
-    sed -i "s/^PRIVATE_KEY=.*/PRIVATE_KEY=$PRIVATE_KEY/" "$FILE_NAME"
-    sed -i "s/^WORLD_ADDRESS=.*/WORLD_ADDRESS=$WORLD_ADDRESS #Local World Address/" "$FILE_NAME"
-    sed -i "s/^CHAIN_ID=.*/CHAIN_ID=$CHAIN_ID #Local Chain ID/" "$FILE_NAME"
-    sed -i "s|^RPC_URL=.*|RPC_URL=$RPC_URL #Forked Anvil Forked Anvil Local RPC Url|" "$FILE_NAME"
+    OS=$(uname)
+    if [ "${OS:-}" = "Darwin" ]; then
+      set -- -i ''
+    else
+      set -- -i
+    fi
+    sed "$@" "s/^PRIVATE_KEY=.*/PRIVATE_KEY=$PRIVATE_KEY/" "$FILE_NAME"
+    sed "$@" "s/^WORLD_ADDRESS=.*/WORLD_ADDRESS=$WORLD_ADDRESS #Local World Address/" "$FILE_NAME"
+    sed "$@" "s/^CHAIN_ID=.*/CHAIN_ID=$CHAIN_ID #Local Chain ID/" "$FILE_NAME"
+    sed "$@" "s|^RPC_URL=.*|RPC_URL=$RPC_URL #Forked Anvil Forked Anvil Local RPC Url|" "$FILE_NAME"
 
     printf "\n${GREEN}[SANITIZED]${RESET} file ${YELLOW}${FILE_NAME}${RESET}\n\n"
 }

--- a/sanitizeEnv.sh
+++ b/sanitizeEnv.sh
@@ -22,10 +22,10 @@ function sanitize() {
         printf "\n%b[NOOP]%b file %b%s%b does not exist. Skipping...\n\n" "${GREEN}" "${RESET}" "${GREEN}" "${FILE_NAME}" "${RESET}"
         return
     fi
-    sed "$@" "s/^PRIVATE_KEY=.*/PRIVATE_KEY=$PRIVATE_KEY/" "$FILE_NAME"
-    sed "$@" "s/^WORLD_ADDRESS=.*/WORLD_ADDRESS=$WORLD_ADDRESS #Local World Address/" "$FILE_NAME"
-    sed "$@" "s/^CHAIN_ID=.*/CHAIN_ID=$CHAIN_ID #Local Chain ID/" "$FILE_NAME"
-    sed "$@" "s|^RPC_URL=.*|RPC_URL=$RPC_URL #Forked Anvil Forked Anvil Local RPC Url|" "$FILE_NAME"
+    sed "$@" 's/^PRIVATE_KEY=.*/PRIVATE_KEY='"$PRIVATE_KEY"'/' "$FILE_NAME"
+    sed "$@" 's/^WORLD_ADDRESS=.*/WORLD_ADDRESS='"$WORLD_ADDRESS"' #Local World Address/' "$FILE_NAME"
+    sed "$@" 's/^CHAIN_ID=.*/CHAIN_ID='"$CHAIN_ID"' #Local Chain ID/' "$FILE_NAME"
+    sed "$@" 's|^RPC_URL=.*|RPC_URL='"$RPC_URL"' #Forked Anvil Forked Anvil Local RPC Url|' "$FILE_NAME"
 
     printf "\n%b[SANITIZED]%b file %b%s%b\n\n" "${GREEN}" "${RESET}" "${YELLOW}" "${FILE_NAME}" "${RESET}"
 }

--- a/sanitizeEnv.sh
+++ b/sanitizeEnv.sh
@@ -18,6 +18,10 @@ function sanitize() {
     else
       set -- -i
     fi
+    if [ ! -f "$FILE_NAME" ]; then
+        printf "\n%b[NOOP]%b file %b%s%b does not exist. Skipping...\n\n" "${GREEN}" "${RESET}" "${GREEN}" "${FILE_NAME}" "${RESET}"
+        return
+    fi
     sed "$@" "s/^PRIVATE_KEY=.*/PRIVATE_KEY=$PRIVATE_KEY/" "$FILE_NAME"
     sed "$@" "s/^WORLD_ADDRESS=.*/WORLD_ADDRESS=$WORLD_ADDRESS #Local World Address/" "$FILE_NAME"
     sed "$@" "s/^CHAIN_ID=.*/CHAIN_ID=$CHAIN_ID #Local Chain ID/" "$FILE_NAME"


### PR DESCRIPTION
Used the `sanitizeEnv.sh` script, made some changes:
- Support BSD `sed`
- `printf` shellcheck fix
- suppress erroneous errors when file(s) don't exist

The script isn't executable and is missing a shebang, wasn't sure if there was a reason for that or not.