### PR TITLE
Smart Turret fails with `Access_NotOwner`

### DIFF
--- a/smart-turret/packages/contracts/script/ConfigureSmartTurret.s.sol
+++ b/smart-turret/packages/contracts/script/ConfigureSmartTurret.s.sol
@@ -16,7 +16,7 @@ import { SmartTurretSystem as CustomSmartTurretSystem } from "../src/systems/Sma
 contract ConfigureSmartTurret is Script {
   function run(address worldAddress) external {
     // Load the private key from the `PRIVATE_KEY` environment variable (in .env)
-    uint256 deployerPrivateKey = vm.envUint("TEST_PLAYER_PRIVATE_KEY");
+    uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
     vm.startBroadcast(deployerPrivateKey);
 
     StoreSwitch.setStoreAddress(worldAddress);


### PR DESCRIPTION
This changes `ConfigureSmartTurret.s.sol` to read the player's private key instead of the test private key. Reading the test private key results in `Access_NotOwner` when interfacing with `eve-stillness`.

Discovered in Discord thread: https://discord.com/channels/1021714190102175754/1430033908359237682/1430397779003445289