### PR TITLE
Smart Turret fails with "Access Denied. You are not the owner of this gate"

### DIFF
--- a/smart-turret/packages/contracts/script/ConfigureSmartTurret.s.sol
+++ b/smart-turret/packages/contracts/script/ConfigureSmartTurret.s.sol
@@ -37,7 +37,7 @@ contract ConfigureSmartTurret is Script {
     
     world.call(
       systemId,
-      abi.encodeCall(CustomSmartTurretSystem.setAllowedTribe, (allowedTribeId))
+      abi.encodeCall(CustomSmartTurretSystem.setAllowedTribe, (smartTurretId, allowedTribeId))
     );
 
     vm.stopBroadcast();

--- a/smart-turret/packages/contracts/src/systems/SmartTurretSystem.sol
+++ b/smart-turret/packages/contracts/src/systems/SmartTurretSystem.sol
@@ -217,11 +217,11 @@ contract SmartTurretSystem is System {
   /**
    * @dev a function to set the allowed tribe which does not get targeted by the Smart Turret
    * @param tribeID is the allowed tribe
-   * @notice this function is only callable by the admin
+   * @notice this function is only callable by the owner of the smart turret
    */
-  function setAllowedTribe(uint256 tribeID) public {
+  function setAllowedTribe(uint256 smartTurretId, uint256 tribeID) public {
     // Ensure it's the admin calling this function
-    require(accessSystem.isAdmin(_msgSender()), "You are not authorized to set the allowed tribe");
+    require(accessSystem.isOwner(smartTurretId, _msgSender()), "You are not authorized to set the allowed tribe");
 
     // Validation check on the tribe ID
     require(tribeID > 1000, "Invalid Tribe ID");

--- a/smart-turret/packages/contracts/test/SmartTurretTest.t.sol
+++ b/smart-turret/packages/contracts/test/SmartTurretTest.t.sol
@@ -106,7 +106,7 @@ contract SmartTurretTest is MudTest {
       systemId,
       abi.encodeCall(
         CustomSmartTurretSystem.setAllowedTribe,
-        (ALLOWED_TRIBE_ID)
+        (smartTurretId, ALLOWED_TRIBE_ID)
       )
     );
     vm.stopPrank();
@@ -160,7 +160,7 @@ contract SmartTurretTest is MudTest {
       systemId,
       abi.encodeCall(
         CustomSmartTurretSystem.setAllowedTribe,
-        (2000)
+        (smartTurretId, 2000)
       )
     );
 
@@ -178,7 +178,7 @@ contract SmartTurretTest is MudTest {
       systemId,
       abi.encodeCall(
         CustomSmartTurretSystem.setAllowedTribe,
-        (2000)
+        (smartTurretId, 2000)
       )
     );
 
@@ -199,7 +199,7 @@ contract SmartTurretTest is MudTest {
       systemId,
       abi.encodeCall(
         CustomSmartTurretSystem.setAllowedTribe,
-        (200)
+        (smartTurretId, 200)
       )
     );
 


### PR DESCRIPTION
The smart turret code's `setAllowedTribe` function fails unless the user is a CCP admin.

This changes `setAllowedTribe` to check if the user is the turret's owner instead.

I was able to run the smart-turret script to completion with this change in conjunction with #133.

```
[554]rusty@HPE-XHD22YD7DW:~/gitstuffs/rustydb/builder-examples/smart-turret/packages/contracts> pnpm configure

> contracts@0.0.0 configure /Users/rusty/gitstuffs/rustydb/builder-examples/smart-turret/packages/contracts
> . ./.env && pnpm forge script ./script/ConfigureSmartTurret.s.sol:ConfigureSmartTurret --broadcast --rpc-url $RPC_URL --chain-id $CHAIN_ID --sig "run(address)" $WORLD_ADDRESS -vvv

Warning: Found unknown `fuzz_runs` config for profile `default` defined in foundry.toml.
[⠢] Compiling...
No files changed, compilation skipped
Script ran successfully.

## Setting up 1 EVM.

==========================

Chain 695569

Estimated gas price: 0.0001001 gwei

Estimated total gas used for script: 1415021465

Estimated amount required: 0.0001416436486465 ETH

==========================

Transactions saved to: /Users/rusty/gitstuffs/rustydb/builder-examples/smart-turret/packages/contracts/broadcast/ConfigureSmartTurret.s.sol/695569/run-latest.json

Sensitive values saved to: /Users/rusty/gitstuffs/rustydb/builder-examples/smart-turret/packages/contracts/cache/ConfigureSmartTurret.s.sol/695569/run-latest.json

Error: Failed to send transaction

Context:
- server returned an error response: error code -32000: exceeds block gas limit
 ELIFECYCLE  Command failed with exit code 1.
```
I don't think the gas error has anything to do with this code change, but I could be mistaken.